### PR TITLE
Add SV, Includes, and Wildcard Support

### DIFF
--- a/cocotb/caravel_cocotb/scripts/verify_cocotb/RunTest.py
+++ b/cocotb/caravel_cocotb/scripts/verify_cocotb/RunTest.py
@@ -124,6 +124,8 @@ class RunTest:
         self.iverilog_dirs = " "
         self.iverilog_dirs += f'-I {self.paths.USER_PROJECT_ROOT}/verilog/rtl'
         self.test.set_user_project()
+        for include_dir in self.test.include_dirs:
+            self.iverilog_dirs += f' -I {include_dir}'
 
     def iverilog_compile(self):
         macros = " -D" + " -D".join(self.test.macros)

--- a/cocotb/caravel_cocotb/scripts/verify_cocotb/Test.py
+++ b/cocotb/caravel_cocotb/scripts/verify_cocotb/Test.py
@@ -26,6 +26,7 @@ class Test:
         self.paths = paths
         self.hex_dir = f"{self.paths.SIM_PATH}/hex_files/"
         self.local_macros = local_macros  # macros for this test only has  to run local macros
+        self.include_dirs = set()
         self.init_test()
 
     def init_test(self):
@@ -299,7 +300,6 @@ class Test:
 
     def convert_list_to_include(self, file):
         paths = ""
-        includes = set()
         with open(file, "r") as f:
             for line in f:
                 # Remove leading and trailing whitespace
@@ -319,23 +319,17 @@ class Test:
                     if line.startswith("-v") or line.startswith("-sv"):
                         # Add Verilog or System Verilog, including wildcards
                         split_line = line.split(" ")
-                        
-                        # Add Includes
-                        include_indices = [i for i, flag in enumerate(split_line) if flag == "-I"]
-                        for i in include_indices:
-                            include_dir = split_line[i+1]
-                            for wild_match in glob.glob(include_dir + '/*vh'):
-                                # paths += f'`include "{wild_match}"\n'
-                                includes.add(wild_match)
-                        
                         file_path = split_line[-1]
                         if ("*" in file_path):
                             for wild_match in glob.glob(file_path):
                                 paths += f'`include "{wild_match}"\n'
                         else:
                             paths += f'`include "{file_path}"\n'
-        for include in includes:
-            paths = f'`include "{include}"\n' + paths
+                        # Add Includes to Set
+                        include_indices = [i for i, flag in enumerate(split_line) if flag == "-I"]
+                        for i in include_indices:
+                            self.include_dirs.add(split_line[i+1])
+                                
         return paths
 
 def remove_argument(to_remove, patt):

--- a/cocotb/caravel_cocotb/scripts/verify_cocotb/Test.py
+++ b/cocotb/caravel_cocotb/scripts/verify_cocotb/Test.py
@@ -356,7 +356,6 @@ def move_defines_to_start(filename, pattern):
     # print(defines_lines)
     # Remove the extracted lines from the original list
     lines = [f"{line.strip()}\n" for line in lines if line not in defines_lines]
-    # lines = [f"{line.strip()}\n" for line in lines if line not in defines_lines and "-I" not in line]
     # Insert the extracted lines at the start of the list
     lines = defines_lines + lines
 


### PR DESCRIPTION
Needed the ability to do simulation with the caravel with system verilog based designs.
SV Designs are included using in `includes.rtl.caravel_user_project` with the following syntax:
`-sv -I $(USER_PROJECT_VERILOG)/rtl/peripherals $(USER_PROJECT_VERILOG)/rtl/peripherals/*.sv`

With this PR, caravel-cocotb can now
- parse system verilog files (starting with -sv)
- expand wildcard (*) operator as needed when parsing
- include directories notated with -I flag for `.svh` and `.vh` files